### PR TITLE
Add ldconfig to ecvl images

### DIFF
--- a/Dockerfile.ecvl
+++ b/Dockerfile.ecvl
@@ -70,4 +70,5 @@ RUN mkdir build && \
       -DECVL_DATASET=ON \
       -DECVL_BUILD_EDDL=ON .. && \
     make -j$(nproc) && \
-    make install
+    make install && \
+    ldconfig

--- a/Dockerfile.ecvl-gpu
+++ b/Dockerfile.ecvl-gpu
@@ -71,4 +71,5 @@ RUN mkdir build && \
       -DECVL_GPU=ON \
       -DECVL_BUILD_EDDL=ON .. && \
     make -j$(nproc) && \
-    make install
+    make install && \
+    ldconfig


### PR DESCRIPTION
Call `ldconfig` after installation so that libraries can be found.