### PR TITLE
Extend installation instructions re optional modules

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -135,18 +135,56 @@ Thus, for instance, to install PyECVL 0.4.0::
     python3 -m pip install pyecvl==0.4.0
 
 
-Disabling unwanted modules
+Disabling optional modules
 --------------------------
 
-By default, PyECVL assumes a complete ECVL installation, including optional
-modules (except for the GUI), and builds bindings for all of them. You can
-disable support for specific modules via environment variables. For instance,
-suppose you installed ECVL without OpenSlide support: by default, PyECVL will
-try to build the bindings for OpenSlide-specific ECVL tools and link the
-OpenSlide library, which might not even be present on your system. To avoid
-this, set the ``ECVL_WITH_OPENSLIDE`` environment variable to ``OFF`` (or
-``FALSE``) before building PyECVL. Similarly, you can turn off DICOM and EDDL
-support by setting ``ECVL_WITH_DICOM`` and ``ECVL_EDDL`` to ``OFF``.
+ECVL and PyECVL have a number of optional components whose compilation can be disabled at
+build time.  The build settings for these components must match across the two libraries.
+
+.. warning::
+    If you compile both libraries with the their respective default settings
+    the resulting Python extention won't work. (you'll have undefined symbols)
+
+By default, **PyECVL assumes a complete installation, but ECVL does not**.
+
+That is, PyECVL by default includes all optional modules (except for the GUI),
+and builds bindings for all of them; on the other hand, ECVL includes only a
+subset of the optional components.
+
+You can control the inclusion of specific modules via build variables set at
+library compile time.
+
+This is the list of optional components and respective variable names.
+
++------------+---------------------+----------------------+---------------------+--------------------+
+| Module     | PyECVL Variable     | Default PyECVL Value | ECVL Variable       | Default ECVL Value |
++------------+---------------------+----------------------+---------------------+--------------------+
+| DICOM      | ECVL_WITH_DICOM     | ON                   | ECVL_WITH_DICOM     | OFF                |
+| OPENSLIDE  | ECVL_WITH_OPENSLIDE | ON                   | ECVL_WITH_OPENSLIDE | OFF                |
+| DATASET    | ECVL_DATASET        | ON                   | ECVL_DATASET        | OFF                |
+| EDDL       | ECVL_EDDL           | ON                   | ECVL_BUILD_EDDL     | ON                 |      
++------------+---------------------+----------------------+---------------------+--------------------+
+
+For a description of the modules, [see the ecvl installation instructions](https://github.com/deephealthproject/ecvl).
+
+.. note::
+    To set the variables for the ECVL build, pass them to `cmake` as in:
+
+        cmake -DECVL_SHARED=ON -DECVL_WITH_DICOM=ON
+
+    To set the variables for the PyECVL build, set them in the environment, as in:
+
+        export ECVL_WITH_OPENSLIDE=OFF
+        python3 setup.py install
+
+
+For instance, suppose you wanted to install PyECVL with OpenSlide support:
+1. Build ECVL with at least `-DECVL_WITH_OPENSLIDE=ON`;
+2. Build PyECVL with the **environment variable** `ECVL_WITH_OPENSLIDE=ON` (default value).
+
+Conversely, to build without OpenSlide support:
+1. Build ECVL with `-DECVL_WITH_OPENSLIDE=OFF` (default value);
+2. Build PyECVL with the **environment variable** `ECVL_WITH_OPENSLIDE=OFF`.
 
 
 ECVL installed in an arbitrary directory
@@ -176,3 +214,30 @@ In this way, ``setup.py`` will look for additional include files in
 
 Similarly, if EDDL is installed in an arbitrary path, you can tell the setup
 script via the ``EDDL_DIR`` environment variable.
+
+
+FAQ
+-----
+
+ImportError: undefined symbol ... ecvl ... OpenSlide
++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+You likely have an ECVL library build without OpenSlide support
+(`ECVL_WITH_OPENSLIDE=OFF` -- default value) and PyECVL library build with
+OpenSlide support (`ECVL_WITH_OPENSLIDE=ON` -- default value).
+
+The full stack trace might look like this:
+::
+    ImportError                               Traceback (most recent call last)
+    <ipython-input-3-ee58876f5538> in <module>
+          4 
+          5 import numpy as np
+    ----> 6 import pyecvl.ecvl as ecvl
+          7 import pyeddl.eddl as eddl
+          8 import pyeddl.eddlT as eddlT~/projects/p138-dh2/.conda/envs/p138-dh2-env-kdh467/lib/python3.6/site-packages/pyecvl/ecvl.py in <module>
+         19 # SOFTWARE.
+         20 
+    ---> 21 from . import _core
+         22 _ecvl = _core.ecvl
+         23 ImportError: /home/jovyan/projects/p138-dh2/.conda/envs/p138-dh2-env-kdh467/lib/python3.6/site-packages/pyecvl/_core.cpython-36m-x86_64-linux-gnu.so: undefined symbol: _ZN4ecvl18OpenSlideGetLevelsERKNSt10filesystem7__cxx114pathERSt6vectorISt5arrayIiLm2EESaIS7_EE
+

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -143,7 +143,7 @@ build time.  The build settings for these components must match across the two l
 
 .. warning::
     If you compile both libraries with the their respective default settings
-    the resulting Python extention won't work. (you'll have undefined symbols)
+    the resulting Python extention won't work (you'll have undefined symbols).
 
 By default, **PyECVL assumes a complete installation, but ECVL does not**.
 
@@ -158,33 +158,41 @@ This is the list of optional components and respective variable names.
 
 +------------+---------------------+----------------------+---------------------+--------------------+
 | Module     | PyECVL Variable     | Default PyECVL Value | ECVL Variable       | Default ECVL Value |
-+------------+---------------------+----------------------+---------------------+--------------------+
++============+=====================+======================+=====================+====================+
 | DICOM      | ECVL_WITH_DICOM     | ON                   | ECVL_WITH_DICOM     | OFF                |
++------------+---------------------+----------------------+---------------------+--------------------+
 | OPENSLIDE  | ECVL_WITH_OPENSLIDE | ON                   | ECVL_WITH_OPENSLIDE | OFF                |
-| DATASET    | ECVL_DATASET        | ON                   | ECVL_DATASET        | OFF                |
++------------+---------------------+----------------------+---------------------+--------------------+
+| DATASET    | (N/A)               | ON                   | ECVL_DATASET        | OFF                |
++------------+---------------------+----------------------+---------------------+--------------------+
 | EDDL       | ECVL_EDDL           | ON                   | ECVL_BUILD_EDDL     | ON                 |      
 +------------+---------------------+----------------------+---------------------+--------------------+
+
+Note that it's currently not possible to turn off the ``DATASET`` module in
+PyECVL, so you *must* compile ECVL with ``ECVL_DATASET`` support.
 
 For a description of the modules, [see the ecvl installation instructions](https://github.com/deephealthproject/ecvl).
 
 .. note::
+
     To set the variables for the ECVL build, pass them to `cmake` as in:
 
-        cmake -DECVL_SHARED=ON -DECVL_WITH_DICOM=ON
+        ``cmake -DECVL_SHARED=ON -DECVL_WITH_DICOM=ON``
 
     To set the variables for the PyECVL build, set them in the environment, as in:
 
-        export ECVL_WITH_OPENSLIDE=OFF
-        python3 setup.py install
+        ``export ECVL_WITH_OPENSLIDE=OFF; python3 setup.py install``
 
 
 For instance, suppose you wanted to install PyECVL with OpenSlide support:
-1. Build ECVL with at least `-DECVL_WITH_OPENSLIDE=ON`;
-2. Build PyECVL with the **environment variable** `ECVL_WITH_OPENSLIDE=ON` (default value).
+
+1. Build ECVL with at least ``-DECVL_WITH_OPENSLIDE=ON``;
+2. Build PyECVL with the **environment variable** ``ECVL_WITH_OPENSLIDE=ON`` (default value).
 
 Conversely, to build without OpenSlide support:
-1. Build ECVL with `-DECVL_WITH_OPENSLIDE=OFF` (default value);
-2. Build PyECVL with the **environment variable** `ECVL_WITH_OPENSLIDE=OFF`.
+
+1. Build ECVL with ``-DECVL_WITH_OPENSLIDE=OFF`` (default value);
+2. Build PyECVL with the **environment variable** ``ECVL_WITH_OPENSLIDE=OFF``.
 
 
 ECVL installed in an arbitrary directory
@@ -223,11 +231,11 @@ ImportError: undefined symbol ... ecvl ... OpenSlide
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 You likely have an ECVL library build without OpenSlide support
-(`ECVL_WITH_OPENSLIDE=OFF` -- default value) and PyECVL library build with
-OpenSlide support (`ECVL_WITH_OPENSLIDE=ON` -- default value).
+(``ECVL_WITH_OPENSLIDE=OFF`` -- default value) and PyECVL library build with
+OpenSlide support (``ECVL_WITH_OPENSLIDE=ON`` -- default value).
 
-The full stack trace might look like this:
-::
+The full stack trace might look like this::
+
     ImportError                               Traceback (most recent call last)
     <ipython-input-3-ee58876f5538> in <module>
           4 


### PR DESCRIPTION
This PR extends the installation instructions pertaining to how to handle optional modules in PyECVL and ECVL and includes a table with the various variable names and their default values.