### PR TITLE
Update pyeddl submodule to latest release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,10 +25,10 @@ jobs:
         run: |
           pip install flake8
           flake8 -v .
-      - name: build eddl image
-        run: pushd third_party/pyeddl; docker build -t eddl -f Dockerfile.eddl .; popd
-      - name: build ecvl image
-        run: docker build -t ecvl -f Dockerfile.ecvl .
+      - name: get prebuilt ecvl image
+        run: |
+          docker pull simleo/ecvl:latest
+          docker tag simleo/ecvl:latest ecvl:latest
       - name: build pyecvl image
         run: docker build -t pyecvl .
       - name: run tests

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
                     agent {
                         docker {
                             label 'docker'
-                            image 'simleo/pyecvl-base:45eb941-f54581c'
+                            image 'simleo/pyecvl-base:45eb941-1e82e5c'
                         }
                     }
                     stages {


### PR DESCRIPTION
Bumps the pyeddl dep to 1.0.0. Also makes the CI build much faster by using a prebuilt image with the expected versions of ecvl and eddl.
